### PR TITLE
Fix: Update Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "ffmpeg-static": "^5.0.0",
-        "libsodium-wrappers": "^0.7.11",
         "mongoose": "^7.3.4",
-        "node-opus": "^0.3.3",
         "scrape-it": "^6.0.1",
         "speedtest-net": "github:RfadnjdExt/speedtest.net"
     },

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
         "@discordjs/opus": "^0.9.0",
         "@distube/deezer": "^1.0.0",
         "@distube/soundcloud": "^1.3.3",
-        "@distube/spotify": "^1.5.1",
+        "@distube/spotify": "github:RfadnjdExt/spotify",
         "@distube/yt-dlp": "^1.1.3",
         "axios": "^1.4.0",
         "discord.js": "^14.11.0",
-        "libsodium-wrappers": "^0.7.11",
-        "distube": "^4.0.5",
+        "distube": "github:RfadnjdExt/DisTube",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "ffmpeg-static": "^5.0.0",
+        "libsodium-wrappers": "^0.7.11",
         "mongoose": "^7.3.4",
         "node-opus": "^0.3.3",
         "scrape-it": "^6.0.1",
@@ -40,8 +40,8 @@
         "node": ">=18.x"
     },
     "devDependencies": {
-        "nodemon": "^3.0.1",
         "@clack/prompts": "^0.6.3",
+        "nodemon": "^3.0.1",
         "opencommit": "^2.4.2",
         "prettier": "^3.0.0",
         "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "ffmpeg-static": "^5.0.0",
         "mongoose": "^7.3.4",
         "scrape-it": "^6.0.1",
+        "sodium": "^3.0.2",
         "speedtest-net": "github:RfadnjdExt/speedtest.net"
     },
     "prettier": {


### PR DESCRIPTION
This pull request updates the dependencies in the project. 

Changes:
- Updated `@distube/spotify` to `github:RfadnjdExt/spotify`
- Updated `distube` to `github:RfadnjdExt/DisTube`
- Removed unused dependencies: `libsodium-wrappers` and `node-opus`

These updates ensure that the project stays up-to-date with the latest changes. Thanks!